### PR TITLE
🎉  1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/g-emoji-element",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/g-emoji-element",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Backports native emoji characters to browsers that don't support them by replacing the characters with fallback images.",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
`<g-emoji>` has been stable and used in github.com for many years. Let's bump it to `1.0.0`!
