### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @github/web-systems-reviewers


### PR DESCRIPTION
Instead of getting all of @github/web-systems to watch this repo for pull requests that are opened, this PR adds the team as CODEOWNERS of all the files in the repo so that they are pinged on all PRs.

This has the obvious drawback of not pinging the team on issues opened, so maybe we should find a better solution but I'm interested in hearing what you think.