### PR TITLE
Much better emoji detection

### DIFF
--- a/emoji-detection.js
+++ b/emoji-detection.js
@@ -1,11 +1,19 @@
 /* @flow strict */
 
 export function isEmojiSupported(): boolean {
-  const onWindows7 = /\bWindows NT 6.1\b/.test(navigator.userAgent)
-  const onWindows8 = /\bWindows NT 6.2\b/.test(navigator.userAgent)
-  const onWindows81 = /\bWindows NT 6.3\b/.test(navigator.userAgent)
-  const onFreeBSD = /\bFreeBSD\b/.test(navigator.userAgent)
-  const onLinux = /\bLinux\b/.test(navigator.userAgent)
-
-  return !(onWindows7 || onWindows8 || onWindows81 || onLinux || onFreeBSD)
+  var node = createElement('canvas');
+  var ctx = node.getContext('2d');
+  var backingStoreRatio =
+    ctx.webkitBackingStorePixelRatio ||
+    ctx.mozBackingStorePixelRatio ||
+    ctx.msBackingStorePixelRatio ||
+    ctx.oBackingStorePixelRatio ||
+    ctx.backingStorePixelRatio ||
+    1;
+  var offset = 12 * backingStoreRatio;
+  ctx.fillStyle = '#f00';
+  ctx.textBaseline = 'top';
+  ctx.font = '32px Arial';
+  ctx.fillText('\ud83d\udc28', 0, 0); // U+1F428 KOALA
+  return ctx.getImageData(offset, offset, 1, 1).data[0] !== 0;
 }


### PR DESCRIPTION
Try to paint a font (in the Emoji range) to canvas and read a pixel using getImageData. If the pixel's Alpha channel `data[3]` you're interested in is not transparent (like for example in the center of ￿) than might be an Emoji. 

This doesn't depend on the version the navigator is using, so if the user removed the emoji font from its system, the script will detect it.