### PR TITLE
Update skin tone only when tone attribute exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,10 @@ class GEmojiElement extends HTMLElement {
       image.src = this.getAttribute('fallback-src') || ''
       this.appendChild(image)
     }
-    updateTone(this)
+
+    if (this.hasAttribute('tone')) {
+      updateTone(this)
+    }
   }
 
   static get observedAttributes(): Array<string> {

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,14 @@ describe('g-emoji', function() {
       assert.equal('G-EMOJI', el.nodeName)
       assert.equal('👋🏻', el.textContent)
     })
+
+    it('does not change skin tone when connected without tone attribute', function() {
+      const el = new window.GEmojiElement()
+      el.textContent = '👋🏻'
+      document.body.append(el)
+      assert.equal('G-EMOJI', el.nodeName)
+      assert.equal('👋🏻', el.textContent)
+    })
   })
 
   describe('in emoji-supporting platforms', function() {


### PR DESCRIPTION
Skip applying skin tones when the element is connected to the document tree when it has no `tone` attribute. This prevents changing an emoji with tone modifiers into its neutral tone variant.