### PR TITLE
Detect non-Androids

### DIFF
--- a/src/emoji-detection.ts
+++ b/src/emoji-detection.ts
@@ -3,7 +3,7 @@ export function isEmojiSupported(): boolean {
   const onWindows8 = /\bWindows NT 6.2\b/.test(navigator.userAgent)
   const onWindows81 = /\bWindows NT 6.3\b/.test(navigator.userAgent)
   const onFreeBSD = /\bFreeBSD\b/.test(navigator.userAgent)
-  const onLinux = /\bLinux\b/.test(navigator.userAgent)
+  const onLinux = /\bLinux\b/.test(navigator.userAgent) && !/\bAndroid\b/.test(navigator.userAgent)
 
   return !(onWindows7 || onWindows8 || onWindows81 || onLinux || onFreeBSD)
 }


### PR DESCRIPTION
https://developer.chrome.com/multidevice/user-agent

```
Mozilla/5.0 (Linux; Android <Version>; <Build Tag etc.>) AppleWebKit/<WebKit Rev> (KHTML, like Gecko) Chrome/<Chrome Rev> Mobile Safari/<WebKit Rev> 
             ^^^^^
```

This isn't a problem with Firefox on Androids, which [uses a format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox#Mobile_and_Tablet_indicators) like

```
Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0
```