### PR TITLE
feat: drop emoji support on linux. Fixes #2

### DIFF
--- a/src/emoji-detection.ts
+++ b/src/emoji-detection.ts
@@ -3,7 +3,6 @@ export function isEmojiSupported(): boolean {
   const onWindows8 = /\bWindows NT 6.2\b/.test(navigator.userAgent)
   const onWindows81 = /\bWindows NT 6.3\b/.test(navigator.userAgent)
   const onFreeBSD = /\bFreeBSD\b/.test(navigator.userAgent)
-  const onLinux = /\bLinux\b/.test(navigator.userAgent) && !/\bAndroid\b/.test(navigator.userAgent)
-
-  return !(onWindows7 || onWindows8 || onWindows81 || onLinux || onFreeBSD)
+  
+  return !(onWindows7 || onWindows8 || onWindows81 || onFreeBSD)
 }


### PR DESCRIPTION
Most Linux distributions come with support for Emoji by installing Noto. Adding fallback images can make things worse for linux users.

Fixes #2 

For example here is Pop!_OS 20.04 (essentially Ubuntu) running Firefox, with native emoji support:

![image](https://user-images.githubusercontent.com/118266/87691991-209c9f80-c783-11ea-900f-066011734658.png)

🦖😁
