### PR TITLE
Allow developers to override emoji support detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,13 +26,9 @@ class GEmojiElement extends HTMLElement {
     this.setAttribute('tone', modifiers)
   }
 
-  static #emojiSupportFunction: () => boolean | null = isEmojiSupported
-  static set emojiSupportFunction(func: () => boolean | null) {
-    this.#emojiSupportFunction = func
-  }
-
+  static emojiSupportFunction = isEmojiSupported
   connectedCallback(): void {
-    if (this.image === null && !GEmojiElement.#emojiSupportFunction()) {
+    if (this.image === null && !GEmojiElement.emojiSupportFunction()) {
       const src = this.getAttribute('fallback-src')
       if (src) {
         this.textContent = ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,13 @@ class GEmojiElement extends HTMLElement {
     this.setAttribute('tone', modifiers)
   }
 
+  static #emojiSupportFunction: () => boolean | null = isEmojiSupported
+  static set emojiSupportFunction(func: () => boolean | null) {
+    this.#emojiSupportFunction = func
+  }
+
   connectedCallback(): void {
-    if (this.image === null && !isEmojiSupported()) {
+    if (this.image === null && !GEmojiElement.#emojiSupportFunction()) {
       const src = this.getAttribute('fallback-src')
       if (src) {
         this.textContent = ''

--- a/test/test.js
+++ b/test/test.js
@@ -216,4 +216,27 @@ describe('g-emoji', function () {
       assert.equal(GEmoji.innerHTML, '<img class="emoji" alt="" height="20" width="20" src="test.png">')
     })
   })
+
+  describe('in application with a custom emoji support function', function () {
+    afterEach(function () {
+      GEmojiElement.emojiSupportFunction = null
+      document.body.innerHTML = ''
+    })
+
+    it('shows the unicode emoji if the function returns true', function () {
+      GEmojiElement.emojiSupportFunction = () => true
+      document.body.innerHTML = '<g-emoji fallback-src="test.png">🦖</g-emoji>'
+
+      const emoji = document.querySelector('g-emoji')
+      assert.equal(emoji.innerHTML, '🦖')
+    })
+
+    it('shows the fall back image if the function returns true', function () {
+      GEmojiElement.emojiSupportFunction = () => false
+      document.body.innerHTML = '<g-emoji fallback-src="test.png">🦖</g-emoji>'
+
+      const emoji = document.querySelector('g-emoji')
+      assert.equal(emoji.innerHTML, '<img class="emoji" alt="" height="20" width="20" src="test.png">')
+    })
+  })
 })


### PR DESCRIPTION
For developers that need/want to detect emoji support themselves, they can now provide a function where they determine if the platform running has emoji support.