### PR TITLE
Export tone modifiers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,8 @@ function emojiImage(el: Element) {
   return image
 }
 
+export {applyTone, removeTone}
+
 export default GEmojiElement
 
 declare global {


### PR DESCRIPTION
## Goal

This PR exports the `applyTone` and `removeTone` functions used for modifying an emoji character. This allows to to programmatically retrieve the value of the tone-adjusted emoji without needing to query to DOM for `<g-emoji>` text content.

This supports https://github.com/github/issues/issues/8264